### PR TITLE
add basic developer environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+FROM fluxrm/flux-sched:focal
+
+LABEL maintainer="Vanessasaurus <@vsoch>"
+
+# Match the default user id for a single system so we aren't root
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=1000
+ENV USERNAME=${USERNAME}
+ENV USER_UID=${USER_UID}
+ENV USER_GID=${USER_GID}
+
+# Switch back to root
+USER root
+
+# Pip not provided in this version
+RUN apt-get update && \
+    apt-get install -y libclang-dev && \
+    apt-get clean
+
+# Assuming installing to /usr/local
+ENV LD_LIBRARY_PATH=/usr/local/lib
+ENV LIBCLANG_PATH=/usr/lib/llvm-10/lib/libclang.so
+
+# Install Rust to a system location via rustup
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+# Install rust nightly
+RUN url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
+
+# Add the group and user that match our ids
+RUN groupadd -g ${USER_GID} ${USERNAME} && \
+    adduser --disabled-password --uid ${USER_UID} --gid ${USER_GID} --gecos "" ${USERNAME} && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+    "name": "Flux in Rust",
+    "dockerFile": "Dockerfile",
+    "context": "../",
+
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash",
+          "python.autoComplete.extraPaths": [
+            "/usr/local/lib/flux/python3.8",
+            "/usr/local/lib/python3.8/site-packages",
+            "/workspaces/flux-core/src/bindings/python"
+          ],
+          "python.analysis.extraPaths": [
+            "/usr/local/lib/flux/python3.8",
+            "/usr/local/lib/python3.8/site-packages",
+            "/workspaces/flux-core/src/bindings/python"
+          ]
+        },
+        "extensions": [
+			"ms-vscode.cpptools",
+			"sumneko.lua",
+			"ms-python.python",
+			"rust-lang.rust-analyzer"
+		]
+      }
+    },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    }
+  },
+  "postStartCommand": "git config --global --add safe.directory /workspaces/flux-rs"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+Cargo.lock
 /target
 **/*.rs.bk

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# flux-rs
+
+Rust bindings (and examples) for Flux.
+
+## Development
+
+A VSCode [Developer Environment](https://code.visualstudio.com/learn/develop-cloud/overview)
+is included for your development. It provides an installation of Flux alongside the rust toolchain.
+You can open the environment by opening VSCode -> View -> Command Palette -> Dev Containers: Rebuild Container.
+Once in the container (or in an environment with cargo) you can do:
+
+```bash
+$ cargo update
+$ cargo build
+```
+
+Note that this uses [flux-framework/flux-sys-rs](https://github.com/flux-framework/flux-sys-rs)
+for system bindings.

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -52,8 +52,7 @@ impl SideFlux {
         let mut child = Command::new("flux")
             .args(&[
                 "start",
-                format!("--size={}", size).as_str(),
-                "--bootstrap=selfpmi",
+                format!("--test-size={}", size).as_str(),
                 "--",
                 "bash",
             ])


### PR DESCRIPTION
This will add a basic README.md and developer environment for VSCode, to mirror the same in https://github.com/flux-framework/flux-depend/. I think I'd like to transform this repository into a "How to rust bindings" akin to the others we have:

 - https://github.com/converged-computing/flux-go
 - https://github.com/converged-computing/flux-c-examples

Which means the examples we can provide next here will be for simple functionality like submit, etc. It's Sunday so I won't ping folks, but I want to ask generally the best way to prototype deeper integrations with Flux. For example, if I want to test a flow of having a user submitting a job and bursting to a cloud, or bursting to a Kubernetes cluster and using Kueue to enforce namespaces, what are approaches for doing that? TLDR I want to be empowered to do experiments with Flux.